### PR TITLE
Generate JDK C++ header files

### DIFF
--- a/scripts/build_jdk.py
+++ b/scripts/build_jdk.py
@@ -32,7 +32,6 @@ def build_java_executable_files() -> None:
     check_call(
         [
             "jlink",
-            "--no-header-files",
             "--no-man-pages",
             "--compress=2",
             "--strip-debug",


### PR DESCRIPTION
In a project, I need the JDK C++ header files.

This only marginally increases the wheel size: 
Before: `Created wheel for jdk4py: filename=jdk4py-17.0.9.0-py3-none-any.whl size=35424621 sha256=912b4aabe0bface151ed995c4c2ea2270e0be5a32a28b221ea138c00204d539e`
After: `Created wheel for jdk4py: filename=jdk4py-17.0.9.0-py3-none-any.whl size=35460052 sha256=dbf3f6a0dae3104eb1b17e5ea74b6262dcb00890de02648806cfb49b9e510815`