### PR TITLE
Add support for ARM64 architecture on Linux

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -12,13 +12,14 @@ jobs:
       matrix:
         architecture:
           - x64
+          - arm64
         os:
           - macos-13
           - ubuntu-22.04
           - windows-2022
-        include:
+        exclude:
           - architecture: arm64
-            os: macos-14
+            os: windows-2022
     name: Deploy on ${{ matrix.os }}-${{ matrix.architecture }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         architecture:
           - x64
+          - arm64
         os:
           - macos-13
           - ubuntu-22.04
@@ -17,9 +18,6 @@ jobs:
         python:
           - "3.12"
         include:
-          - architecture: arm64
-            os: macos-14
-            python: "3.12"
           - architecture: x64
             os: ubuntu-22.04
             python: "3.11"
@@ -29,6 +27,10 @@ jobs:
           - architecture: x64
             os: ubuntu-22.04
             python: "3.9"
+        exclude:
+          - architecture: arm64
+            os: windows-2022
+            python: "3.12"
       fail-fast: false
     name: Test on ${{ matrix.os }}-${{ matrix.architecture }} with Python ${{ matrix.python }}
     steps:
@@ -74,13 +76,14 @@ jobs:
       matrix:
         architecture:
           - x64
+          - arm64
         os:
           - macos-13
           - ubuntu-22.04
           - windows-2022
         include:
           - architecture: arm64
-            os: macos-14
+            os: windows-2022
     name: Test Conda packaging on ${{ matrix.os }}-${{ matrix.architecture }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,7 +81,7 @@ jobs:
           - macos-13
           - ubuntu-22.04
           - windows-2022
-        include:
+        exclude:
           - architecture: arm64
             os: windows-2022
     name: Test Conda packaging on ${{ matrix.os }}-${{ matrix.architecture }}

--- a/scripts/set_environment.py
+++ b/scripts/set_environment.py
@@ -33,6 +33,10 @@ _SYSTEM_TO_ARCHITECTURE_TO_PACKAGE_TYPE_TO_PLATFORM: Mapping[
         },
     },
     "Linux": {
+        "aarch64": {
+            "conda": "linux-arm64",
+            "wheel": "manylinux1_arm64",
+        },
         "x64": {
             "conda": "linux-64",
             "wheel": "manylinux1_x86_64",


### PR DESCRIPTION
Close #73.

`ARM64` runners [are now available in GitHub Actions](https://github.blog/changelog/2024-06-03-actions-arm-based-linux-and-windows-runners-are-now-in-public-beta/).
